### PR TITLE
Support initial 2fa confirmation

### DIFF
--- a/src/stubs/resources/js/Pages/Profile/Show.tsx
+++ b/src/stubs/resources/js/Pages/Profile/Show.tsx
@@ -11,9 +11,13 @@ import { Session } from '@/types';
 
 interface Props {
   sessions: Session[];
+  confirmsTwoFactorAuthentication: boolean;
 }
 
-export default function Show({ sessions }: Props) {
+export default function Show({
+  sessions,
+  confirmsTwoFactorAuthentication,
+}: Props) {
   const page = useTypedPage();
 
   return (
@@ -45,7 +49,9 @@ export default function Show({ sessions }: Props) {
 
           {page.props.jetstream.canManageTwoFactorAuthentication ? (
             <div className="mt-10 sm:mt-0">
-              <TwoFactorAuthenticationForm />
+              <TwoFactorAuthenticationForm
+                requiresConfirmation={confirmsTwoFactorAuthentication}
+              />
 
               <JetSectionBorder />
             </div>


### PR DESCRIPTION
As per https://github.com/ozziexsh/laravel-jetstream-react/issues/11

Supports entering the 2fa code before enabling to ensure it works

Updated from

https://github.com/laravel/jetstream/blob/2.x/stubs/inertia/resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue