### PR TITLE
Run nightly job to ensure command works

### DIFF
--- a/.github/workflows/nightly-clone.yml
+++ b/.github/workflows/nightly-clone.yml
@@ -1,4 +1,6 @@
-on: push
+on:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   ensure_conversion_works:

--- a/.github/workflows/nightly-clone.yml
+++ b/.github/workflows/nightly-clone.yml
@@ -29,4 +29,4 @@ jobs:
           cd myapp
           composer require laravel/jetstream
           php artisan jetstream:install inertia $FLAGS
-          npx laravel-jetstream-react install $FLAGS
+          npx laravel-jetstream-react install --force $FLAGS

--- a/.github/workflows/nightly_clone.yml
+++ b/.github/workflows/nightly_clone.yml
@@ -1,0 +1,32 @@
+on: push
+
+jobs:
+  ensure_conversion_works:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Normal Conversion
+            flags: ''
+          - name: Teams Conversion
+            flags: '--teams'
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Test the conversion works
+        env:
+          FLAGS: ${{ matrix.flags }}
+        run: |
+          composer create-project laravel/laravel myapp
+          cd myapp
+          composer require laravel/jetstream
+          php artisan jetstream:install inertia $FLAGS
+          npx laravel-jetstream-react install $FLAGS

--- a/.github/workflows/test-conversion.yml
+++ b/.github/workflows/test-conversion.yml
@@ -28,6 +28,7 @@ jobs:
           FLAGS: ${{ matrix.flags }}
         run: |
           npm install
+          npm run build
           npm link
           composer create-project laravel/laravel myapp
           cd myapp

--- a/.github/workflows/test-conversion.yml
+++ b/.github/workflows/test-conversion.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           FLAGS: ${{ matrix.flags }}
         run: |
+          npm install
           npm link
           composer create-project laravel/laravel myapp
           cd myapp

--- a/.github/workflows/test-conversion.yml
+++ b/.github/workflows/test-conversion.yml
@@ -1,0 +1,36 @@
+on: push
+
+jobs:
+  ensure_conversion_works:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Normal Conversion
+            flags: ''
+          - name: Teams Conversion
+            flags: '--teams'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Test the conversion works
+        env:
+          FLAGS: ${{ matrix.flags }}
+        run: |
+          npm link
+          composer create-project laravel/laravel myapp
+          cd myapp
+          composer require laravel/jetstream
+          php artisan jetstream:install inertia $FLAGS
+          npm link laravel-jetstream-react
+          npx laravel-jetstream-react install --force $FLAGS

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -10,10 +10,12 @@ export default class Install extends Command {
   static examples = [
     '$ laravel-jetstream-react install',
     '$ laravel-jetstream-react install --teams',
+    '$ laravel-jetstream-react install --force',
   ];
 
   static flags = {
     teams: Flags.boolean({ default: false }),
+    force: Flags.boolean({ default: false }),
   };
 
   static args = [];
@@ -73,16 +75,20 @@ export default class Install extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(Install);
+
     this.warn(
       'This installer assumes a FRESH install of Laravel Jetstream using the Inertia + Vue option.',
     );
-    this.warn(
-      'This will overwrite multiple files in this project, do you wish to continue?',
-    );
-    const confirm: string = await CliUx.ux.prompt('Continue? (y/n)');
-    if (confirm.toLowerCase() !== 'y' && confirm.toLowerCase() !== 'yes') {
-      this.log('Exiting');
-      this.exit(0);
+
+    if (!flags.force) {
+      this.warn(
+        'This will overwrite multiple files in this project, do you wish to continue?',
+      );
+      const confirm: string = await CliUx.ux.prompt('Continue? (y/n)');
+      if (confirm.toLowerCase() !== 'y' && confirm.toLowerCase() !== 'yes') {
+        this.log('Exiting');
+        this.exit(0);
+      }
     }
 
     if (fs.existsSync(path.join(process.cwd(), 'node_modules'))) {
@@ -140,6 +146,7 @@ export default class Install extends Command {
     }
 
     this.log('Installation complete. Enjoy :)');
+    this.exit(0);
   }
 
   private moveStub(stubPath: string, localPath: string) {


### PR DESCRIPTION
recently the cli stopped working due to upgrades in dependencies. this pr introduces two github actions

- a nightly job that creates a new laravel project and runs both the normal and teams conversions using the hosted npm package
- a job on each pr to see if the local changes convert a project properly

needed to add a `--force` flag to run on ci