### PR TITLE
Replacing `Dialog.Overlay` with `div` on Modal.tsx

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -41,7 +41,7 @@ export default class Install extends Command {
   };
 
   private deps = {
-    '@headlessui/react': '^1.5.0',
+    '@headlessui/react': '^1.7.4',
     '@inertiajs/inertia': '^0.11.1',
     '@inertiajs/inertia-react': '^0.8.1',
     '@inertiajs/progress': '^0.2.7',

--- a/src/stubs/resources/js/Components/Modal.tsx
+++ b/src/stubs/resources/js/Components/Modal.tsx
@@ -46,7 +46,7 @@ export default function Modal({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+            <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
           </Transition.Child>
 
           {/* This element is to trick the browser into centering the modal contents. */}


### PR DESCRIPTION
Since headless ui entered version `1.6`, this is no longer needed.

The references can be found [here](https://tailwindcss.com/blog/2022-05-23-headless-ui-v1-6-tailwind-ui-team-management#scrollable-dialog-improvements).