### PR TITLE
Replacing `Dialog.Overlay` with regular `div`.

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -41,7 +41,7 @@ export default class Install extends Command {
   };
 
   private deps = {
-    '@headlessui/react': '^1.5.0',
+    '@headlessui/react': '^1.7.4',
     '@inertiajs/inertia': '^0.11.1',
     '@inertiajs/inertia-react': '^0.8.1',
     '@inertiajs/progress': '^0.2.7',

--- a/src/stubs/resources/js/Components/ApplicationLogo.tsx
+++ b/src/stubs/resources/js/Components/ApplicationLogo.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-export default function ApplicationLogo({
-  className,
-}: {
-  className?: string;
-}) {
+export default function ApplicationLogo({ className }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 317 48"

--- a/src/stubs/resources/js/Components/ApplicationMark.tsx
+++ b/src/stubs/resources/js/Components/ApplicationMark.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-export default function ApplicationMark(
-  props: React.SVGProps<SVGSVGElement>,
-) {
+export default function ApplicationMark(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       viewBox="0 0 48 48"

--- a/src/stubs/resources/js/Components/ConfirmsPassword.tsx
+++ b/src/stubs/resources/js/Components/ConfirmsPassword.tsx
@@ -23,7 +23,7 @@ export default function ConfirmsPassword({
   children,
 }: PropsWithChildren<Props>) {
   const route = useRoute();
-  const [confirmingPassword, setConfirmingPassword] = useState(false);
+  const [confirmingPassword, setConfirmingPassword] = useState<boolean>(false);
   const [form, setForm] = useState({
     password: '',
     error: '',
@@ -73,7 +73,7 @@ export default function ConfirmsPassword({
     <span>
       <span onClick={startConfirmingPassword}>{children}</span>
 
-      <DialogModal isOpen={confirmingPassword} onClose={closeModal}>
+      <DialogModal show={confirmingPassword} onClose={closeModal}>
         <DialogModal.Content title={title}>
           {content}
 

--- a/src/stubs/resources/js/Components/Modal.tsx
+++ b/src/stubs/resources/js/Components/Modal.tsx
@@ -65,14 +65,14 @@ export default function Modal({
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div
+            <Dialog.Panel
               className={classNames(
                 'inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full',
                 maxWidthClass,
               )}
             >
               {children}
-            </div>
+            </Dialog.Panel>
           </Transition.Child>
         </div>
       </Dialog>

--- a/src/stubs/resources/js/Components/Modal.tsx
+++ b/src/stubs/resources/js/Components/Modal.tsx
@@ -46,7 +46,7 @@ export default function Modal({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Dialog.Overlay className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+            <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
           </Transition.Child>
 
           {/* This element is to trick the browser into centering the modal contents. */}

--- a/src/stubs/resources/js/Components/Modal.tsx
+++ b/src/stubs/resources/js/Components/Modal.tsx
@@ -1,82 +1,73 @@
+import React, { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import classNames from 'classnames';
-import React, { PropsWithChildren } from 'react';
-import ReactDOM from 'react-dom';
 
 export interface ModalProps {
-  isOpen: boolean;
-  onClose(): void;
-  maxWidth?: string;
+  children?: React.ReactNode;
+  show?: boolean;
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl';
+  onClose?: () => void;
 }
 
 export default function Modal({
-  isOpen,
-  onClose,
-  maxWidth = '2xl',
   children,
-}: PropsWithChildren<ModalProps>) {
+  show = false,
+  maxWidth = '2xl',
+  onClose,
+}: ModalProps) {
+  const close = () => {
+    if (onClose) {
+      onClose();
+    }
+  };
+
   const maxWidthClass = {
-    sm: 'sm:max-w-sm',
-    md: 'sm:max-w-md',
-    lg: 'sm:max-w-lg',
-    xl: 'sm:max-w-xl',
-    '2xl': 'sm:max-w-2xl',
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
+    '2xl': 'max-w-2xl',
+    '3xl': 'max-w-3xl',
+    '4xl': 'max-w-4xl',
+    '5xl': 'max-w-5xl',
+    '6xl': 'max-w-6xl',
   }[maxWidth];
 
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  return ReactDOM.createPortal(
-    <Transition.Root show={isOpen} as={React.Fragment}>
+  return (
+    <Transition show={show} as={Fragment} leave="duration-200">
       <Dialog
         as="div"
-        static
-        className="fixed z-10 inset-0 overflow-y-auto"
-        open={isOpen}
-        onClose={onClose}
+        id="modal"
+        className="fixed inset-0 z-50 flex transform items-center overflow-y-auto px-4 py-6 transition-all sm:px-0"
+        onClose={close}
       >
-        <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-          <Transition.Child
-            as={React.Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
-          </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="absolute inset-0 bg-black/75" />
+        </Transition.Child>
 
-          {/* This element is to trick the browser into centering the modal contents. */}
-          <span
-            className="hidden sm:inline-block sm:align-middle sm:h-screen"
-            aria-hidden="true"
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          enterTo="opacity-100 translate-y-0 sm:scale-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+          leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        >
+          <Dialog.Panel
+            className={`mb-6 transform overflow-hidden rounded-lg bg-white text-gray-800 shadow-xl transition-all sm:mx-auto sm:w-full ${maxWidthClass}`}
           >
-            &#8203;
-          </span>
-          <Transition.Child
-            as={React.Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-            enterTo="opacity-100 translate-y-0 sm:scale-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          >
-            <Dialog.Panel
-              className={classNames(
-                'inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full',
-                maxWidthClass,
-              )}
-            >
-              {children}
-            </Dialog.Panel>
-          </Transition.Child>
-        </div>
+            {children}
+          </Dialog.Panel>
+        </Transition.Child>
       </Dialog>
-    </Transition.Root>,
-    document.body,
+    </Transition>
   );
 }

--- a/src/stubs/resources/js/Layouts/AppLayout.tsx
+++ b/src/stubs/resources/js/Layouts/AppLayout.tsx
@@ -331,9 +331,7 @@ export default function AppLayout({
 
                 {/* <!-- Authentication --> */}
                 <form method="POST" onSubmit={logout}>
-                  <ResponsiveNavLink as="button">
-                    Log Out
-                  </ResponsiveNavLink>
+                  <ResponsiveNavLink as="button">Log Out</ResponsiveNavLink>
                 </form>
 
                 {/* <!-- Team Management --> */}

--- a/src/stubs/resources/js/Pages/Auth/Register.tsx
+++ b/src/stubs/resources/js/Pages/Auth/Register.tsx
@@ -76,7 +76,9 @@ export default function Register() {
         </div>
 
         <div className="mt-4">
-          <InputLabel htmlFor="password_confirmation">Confirm Password</InputLabel>
+          <InputLabel htmlFor="password_confirmation">
+            Confirm Password
+          </InputLabel>
           <TextInput
             id="password_confirmation"
             type="password"
@@ -88,7 +90,10 @@ export default function Register() {
             required
             autoComplete="new-password"
           />
-          <InputError className="mt-2" message={form.errors.password_confirmation} />
+          <InputError
+            className="mt-2"
+            message={form.errors.password_confirmation}
+          />
         </div>
 
         {page.props.jetstream.hasTermsAndPrivacyPolicyFeature && (

--- a/src/stubs/resources/js/Pages/Auth/ResetPassword.tsx
+++ b/src/stubs/resources/js/Pages/Auth/ResetPassword.tsx
@@ -63,7 +63,9 @@ export default function ResetPassword({ token, email }: Props) {
         </div>
 
         <div className="mt-4">
-          <InputLabel htmlFor="password_confirmation">Confirm Password</InputLabel>
+          <InputLabel htmlFor="password_confirmation">
+            Confirm Password
+          </InputLabel>
           <TextInput
             id="password_confirmation"
             type="password"
@@ -75,7 +77,10 @@ export default function ResetPassword({ token, email }: Props) {
             required
             autoComplete="new-password"
           />
-          <InputError className="mt-2" message={form.errors.password_confirmation} />
+          <InputError
+            className="mt-2"
+            message={form.errors.password_confirmation}
+          />
         </div>
 
         <div className="flex items-center justify-end mt-4">

--- a/src/stubs/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
+++ b/src/stubs/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
@@ -55,7 +55,7 @@ export default function DeleteUserForm() {
       </div>
 
       {/* <!-- Delete Account Confirmation Modal --> */}
-      <DialogModal isOpen={confirmingUserDeletion} onClose={closeModal}>
+      <DialogModal show={confirmingUserDeletion} onClose={closeModal}>
         <DialogModal.Content title={'Delete Account'}>
           Are you sure you want to delete your account? Once your account is
           deleted, all of its resources and data will be permanently deleted.

--- a/src/stubs/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
+++ b/src/stubs/resources/js/Pages/Profile/Partials/DeleteUserForm.tsx
@@ -55,7 +55,7 @@ export default function DeleteUserForm() {
       </div>
 
       {/* <!-- Delete Account Confirmation Modal --> */}
-      <DialogModal show={confirmingUserDeletion} onClose={closeModal}>
+      <DialogModal isOpen={confirmingUserDeletion} onClose={closeModal}>
         <DialogModal.Content title={'Delete Account'}>
           Are you sure you want to delete your account? Once your account is
           deleted, all of its resources and data will be permanently deleted.

--- a/src/stubs/resources/js/Pages/Profile/Partials/UpdatePasswordForm.tsx
+++ b/src/stubs/resources/js/Pages/Profile/Partials/UpdatePasswordForm.tsx
@@ -73,10 +73,7 @@ export default function UpdatePasswordForm() {
           }
           autoComplete="current-password"
         />
-        <InputError
-          message={form.errors.current_password}
-          className="mt-2"
-        />
+        <InputError message={form.errors.current_password} className="mt-2" />
       </div>
 
       <div className="col-span-6 sm:col-span-4">
@@ -94,7 +91,9 @@ export default function UpdatePasswordForm() {
       </div>
 
       <div className="col-span-6 sm:col-span-4">
-        <InputLabel htmlFor="password_confirmation">Confirm Password</InputLabel>
+        <InputLabel htmlFor="password_confirmation">
+          Confirm Password
+        </InputLabel>
         <TextInput
           id="password_confirmation"
           type="password"

--- a/src/stubs/resources/js/Pages/Teams/Partials/DeleteTeamForm.tsx
+++ b/src/stubs/resources/js/Pages/Teams/Partials/DeleteTeamForm.tsx
@@ -39,9 +39,7 @@ export default function DeleteTeamForm({ team }: Props) {
       </div>
 
       <div className="mt-5">
-        <DangerButton onClick={confirmTeamDeletion}>
-          Delete Team
-        </DangerButton>
+        <DangerButton onClick={confirmTeamDeletion}>Delete Team</DangerButton>
       </div>
 
       {/* <!-- Delete Team Confirmation Modal --> */}


### PR DESCRIPTION
Bump headless ui version from `v1.5` to `v1.7`. And since headless ui entered version `1.6`, this is no longer needed.

The references can be found [here](https://tailwindcss.com/blog/2022-05-23-headless-ui-v1-6-tailwind-ui-team-management#scrollable-dialog-improvements).