### PR TITLE
Fix: add missing ref to enable input focus

### DIFF
--- a/src/stubs/resources/js/Components/ConfirmsPassword.tsx
+++ b/src/stubs/resources/js/Components/ConfirmsPassword.tsx
@@ -79,6 +79,7 @@ export default function ConfirmsPassword({
 
           <div className="mt-4">
             <TextInput
+              ref={passwordRef}
               type="password"
               className="mt-1 block w-3/4"
               placeholder="Password"


### PR DESCRIPTION
### This PR
- [x] Adds `passwordRef` to `TextInput` which fixes focus not working. 